### PR TITLE
add fallbacks for when subtitle name is empty

### DIFF
--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -1,3 +1,4 @@
+console.log('zupa');
 var ChromecastSessionManager = require('../chromecast/ChromecastSessionManager'),
     ChromecastTechUI = require('./ChromecastTechUI'),
     SESSION_TIMEOUT = 10 * 1000, // milliseconds
@@ -681,11 +682,17 @@ ChromecastTech = {
          if (event.value && event.value.tracks) {
             event.value.tracks.forEach(function(track) {
                const isAlreadyLoaded = alreadyLoadedTracks.some(function(alreadyLoadedTrack) {
-                  return alreadyLoadedTrack.id === track.name;
+                  return alreadyLoadedTrack.id === track.name || alreadyLoadedTrack.language === track.language;
                });
 
-               if (!isAlreadyLoaded) {
-                  track.id = track.name;
+               if (!isAlreadyLoaded && track.type === 'TEXT' && track.subtype === 'SUBTITLE') {
+                  if (track.name) {
+                     track.id = track.name;
+                  } else if (track.language === 'en') {
+                     track.id = 'English';
+                  } else {
+                     track.id = track.language;
+                  }
                   player.addRemoteTextTrack(track);
                }
             });

--- a/src/js/tech/ChromecastTech.js
+++ b/src/js/tech/ChromecastTech.js
@@ -1,4 +1,3 @@
-console.log('zupa');
 var ChromecastSessionManager = require('../chromecast/ChromecastSessionManager'),
     ChromecastTechUI = require('./ChromecastTechUI'),
     SESSION_TIMEOUT = 10 * 1000, // milliseconds


### PR DESCRIPTION
When `track.name` was empty it was adding serveral subtitles with autogenerated names like VJS_23134